### PR TITLE
CSS touchups

### DIFF
--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -1,7 +1,7 @@
-<footer>
-  <div
-    class="bg-secondary90 border-t-4 border-solid border-tertiary70 flex justify-end gap-4 pr-4 sm:py-6 sm:gap-8"
-  >
+<footer
+  class="sticky bottom-0 bg-secondary90 border-t-4 border-solid border-tertiary70 dark:bg-secondary20 dark:border-tertiary70"
+>
+  <div class="flex justify-end gap-4 pr-4 sm:py-6 sm:gap-8">
     <a
       href="https://github.com/BrettEastman/bretteastmanstudio/"
       target="_blank"

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -108,7 +108,7 @@
                   };
                 }}
               >
-                <button>{`Log Out ${$currentUser.email}`}</button>
+                <button>{`Log Out ${$currentUser.name}`}</button>
               </form>
             </li>
           {:else}
@@ -160,7 +160,7 @@
                 };
               }}
             >
-              <button>{`Log Out ${$currentUser.email}`}</button>
+              <button>{`Log Out ${$currentUser.name}`}</button>
             </form>
           </li>
         {:else}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,6 @@
 import { pb } from "$lib/pocketbase";
 import type { Handle } from "@sveltejs/kit";
+import type { ClientResponseError } from "pocketbase";
 
 export const handle: Handle = async ({ event, resolve }) => {
   // BEFORE
@@ -8,7 +9,10 @@ export const handle: Handle = async ({ event, resolve }) => {
     try {
       await pb.collection("users").authRefresh();
     } catch (error) {
-      console.error("Error refreshing auth:", error);
+      const err = error as ClientResponseError;
+      if (err.status !== 401) {
+        console.error("Unexpected error refreshing auth:", err);
+      }
       pb.authStore.clear();
     }
   }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -4,15 +4,27 @@ import type { ClientResponseError } from "pocketbase";
 
 export const handle: Handle = async ({ event, resolve }) => {
   // BEFORE
+  // Load the authentication state from the cookies in the incoming request.
+  // If no cookie is found, an empty string is used, which effectively means no auth state.
   pb.authStore.loadFromCookie(event.request.headers.get("cookie") || "");
+
+  // Check if the current authentication state is valid, meaning the user is logged in
   if (pb.authStore.isValid) {
     try {
+      // Attempt to refresh the authentication token for the user.
+      // This is typically done to ensure the user session remains active.
       await pb.collection("users").authRefresh();
     } catch (error) {
+      // If an error occurs during the token refresh, handle it here.
       const err = error as ClientResponseError;
+
+      // If the error is not a 401 Unauthorized error, log it as unexpected. Not sure why, but this 401 error kept popping up although the user is logged in.
       if (err.status !== 401) {
         console.error("Unexpected error refreshing auth:", err);
       }
+
+      // Clear the authentication state, effectively logging the user out.
+      // ?? why is this here?
       pb.authStore.clear();
     }
   }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,9 +16,16 @@
         class="hover:text-primary60 duration-200"
         >software engineer,
       </a>
-      {" "}composer,{" "}
+      {" "}<a
+        href="https://www.brettaustineastman.com/selected_works"
+        target="_blank"
+        class="hover:text-primary60 duration-200"
+      >
+        composer,
+      </a>
+      {" "}
       <a
-        href="https://www.brettaustineastman.com/"
+        href="https://www.brettaustineastman.com/about"
         target="_blank"
         class="hover:text-primary60 duration-200"
       >
@@ -32,10 +39,10 @@
     <br />
     <p>
       This website is an archive of various teaching materials Brett created or
-      modified for students over the years. There are several categories of
-      links to PDFs that anyone is welcome to download for free. Note that this
-      collection represents a mix of material that was either useful for
-      teaching music concepts, or requested by the student.
+      modified for students over the years. It is limited collection, but here
+      are several categories of links to PDFs that anyone is welcome to download
+      for free. Note that this collection represents a mix of material that was
+      either useful for teaching music concepts, or requested by the student.
     </p>
     <br />
     <p>

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -5,7 +5,7 @@
 
 <form
   method="POST"
-  class=""
+  class="grid place-items-center"
   use:enhance={() => {
     return async ({ result }) => {
       // when the form is submitted, we need to tell the client to load the user from the cookie
@@ -19,21 +19,21 @@
   >
     Log In
   </h1>
-  <div class="gap-2 mb-4 text-lg">
+  <div class="flex flex-col gap-2 mb-4 text-lg">
     <input
       type="email"
       name="email"
       placeholder="Email"
-      class="input input-bordered"
+      class="bg-secondary100 dark:bg-secondary80 rounded-md p-2"
     />
     <input
       type="password"
       name="password"
       placeholder="Password"
-      class="input input-bordered"
+      class="bg-secondary100 dark:bg-secondary80 rounded-md p-2"
     />
     <button
-      class="text-primary30 font-semibold py-2 sm:py-8 dark:text-secondary90"
+      class="bg-secondary100 dark:bg-secondary80 rounded-md p-2 text-primary30 font-semibold dark:text-secondary90 hover:bg-secondary90 duration-200"
       >Log In</button
     >
   </div>

--- a/src/routes/register/+page.server.ts
+++ b/src/routes/register/+page.server.ts
@@ -4,6 +4,8 @@ import type { Actions } from "./$types";
 export const actions: Actions = {
   default: async ({ request, locals }) => {
     const data = Object.fromEntries(await request.formData()) as {
+      firstName: string;
+      lastName: string;
       email: string;
       password: string;
       passwordConfirm: string;
@@ -12,6 +14,7 @@ export const actions: Actions = {
     try {
       // Create the user with required fields
       const userData = {
+        name: `${data.firstName} ${data.lastName}`,
         email: data.email,
         password: data.password,
         passwordConfirm: data.passwordConfirm,

--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -5,7 +5,7 @@
 
 <form
   method="POST"
-  class=""
+  class="grid place-items-center"
   use:enhance={() => {
     return async ({ result }) => {
       // when the form is submitted, we need to tell the client to load the user from the cookie
@@ -19,27 +19,27 @@
   >
     Register
   </h1>
-  <div class="gap-2 mb-4 text-lg">
+  <div class="flex flex-col gap-2 mb-4 text-lg">
     <input
       type="email"
       name="email"
       placeholder="Email"
-      class="input input-bordered"
+      class="bg-secondary100 dark:bg-secondary80 rounded-md p-2"
     />
     <input
       type="password"
       name="password"
       placeholder="Password"
-      class="input input-bordered"
+      class="bg-secondary100 dark:bg-secondary80 rounded-md p-2"
     />
     <input
       type="password"
       name="passwordConfirm"
       placeholder="Confirm password"
-      class="input input-bordered"
+      class="bg-secondary100 dark:bg-secondary80 rounded-md p-2"
     />
     <button
-      class="text-primary30 font-semibold py-2 sm:py-8 dark:text-secondary90"
+      class="bg-secondary100 dark:bg-secondary80 rounded-md p-2 text-primary30 font-semibold dark:text-secondary90 hover:bg-secondary90 duration-200"
       >Register</button
     >
   </div>

--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -21,6 +21,18 @@
   </h1>
   <div class="flex flex-col gap-2 mb-4 text-lg">
     <input
+      type="text"
+      name="firstName"
+      placeholder="First Name"
+      class="bg-secondary100 dark:bg-secondary80 rounded-md p-2"
+    />
+    <input
+      type="text"
+      name="lastName"
+      placeholder="Last Name"
+      class="bg-secondary100 dark:bg-secondary80 rounded-md p-2"
+    />
+    <input
       type="email"
       name="email"
       placeholder="Email"


### PR DESCRIPTION
- Made Footer sticky, refactor some CSS from one element to a parent element also in Footer.
- Added padding, background color and rounded to all inputs in Register and Log In.
- Reworked text a bit on home page and made "composer" into a link
- Changed error handling in hooks.server.ts "Error refreshing auth: ClientResponseError 401" which kept happening although auth and app were fine: Added if statement to only present errors that are not 401 and added ClientResponseError type to file.
- Added first and last name to registration.
- Included name in the Log Out button on Header.