### PR TITLE
Add more cache control headers

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -46,6 +46,10 @@ export const handle: Handle = async ({ event, resolve }) => {
             "set-cookie",
             pbUser.authStore.exportToCookie(cookieOptions)
           );
+          // Add cache control headers
+          response.headers.set("Cache-Control", "no-store, must-revalidate");
+          response.headers.set("Pragma", "no-cache");
+          response.headers.set("Expires", "0");
         } else {
           // For other errors (network, etc.), keep the existing auth state
           console.warn(

--- a/src/routes/api/auth/logout/+server.ts
+++ b/src/routes/api/auth/logout/+server.ts
@@ -8,18 +8,15 @@ export async function POST({ cookies }) {
   pbUser.authStore.clear();
   const response = json({ message: "Logout successful", success: true });
 
-  // Set multiple cookie clearing headers to ensure it's removed
-  response.headers.append(
+  // Set cache control headers
+  response.headers.set("Cache-Control", "no-store, must-revalidate");
+  response.headers.set("Pragma", "no-cache");
+  response.headers.set("Expires", "0");
+
+  // Clear the cookie with a single, well-formed header
+  response.headers.set(
     "set-cookie",
     `pb_auth=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; httpOnly; ${
-      import.meta.env.PROD ? "secure; " : ""
-    }sameSite=lax`
-  );
-
-  // Also clear with empty quotes version
-  response.headers.append(
-    "set-cookie",
-    `pb_auth=""; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; httpOnly; ${
       import.meta.env.PROD ? "secure; " : ""
     }sameSite=lax`
   );

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -44,7 +44,13 @@ export async function POST({ request, locals }) {
       lastQuestionDate: today,
     });
 
-    return json(record);
+    return json(record, {
+      headers: {
+        "Cache-Control": "no-store, must-revalidate",
+        "Pragma": "no-cache",
+        "Expires": "0"
+      }
+    });
   } catch (error) {
     console.error("Error processing request:", error);
     // Check if it's an authentication error


### PR DESCRIPTION
- Changed response.headers.append back to response.headers.set in auth/logout.
- Added explicit cache control headers for the GET requests and other authentication related responses in api/chat and hooks.server.ts.