### PR TITLE
Fix mobile button press color stickiness

### DIFF
--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -23,11 +23,3 @@
     </a>
   </div>
 </footer>
-
-<!-- <style>
-  @media (hover: hover) {
-    .hover:text-tertiary60 {
-      color: var(--tertiary80);
-    }
-  }
-</style> -->

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -11,15 +11,23 @@
     <a
       href="https://github.com/BrettEastman/bretteastmanstudio/"
       target="_blank"
-      class="text-primary30 dark:text-primary50 hover:text-tertiary60 duration-200"
+      class="text-primary30 dark:text-primary50 active:text-tertiary80 transition duration-200"
       ><Icon name="github" className="fill-current" size="36" />
     </a>
 
     <a
       href="https://www.linkedin.com/in/brett-austin-eastman/"
       target="_blank"
-      class="text-primary30 dark:text-primary50 hover:text-tertiary60 duration-200"
+      class="text-primary30 dark:text-primary50 active:text-tertiary80 transition duration-200"
       ><Icon name="linkedin" className="fill-current" size="36" />
     </a>
   </div>
 </footer>
+
+<!-- <style>
+  @media (hover: hover) {
+    .hover:text-tertiary60 {
+      color: var(--tertiary80);
+    }
+  }
+</style> -->

--- a/src/components/ResourceDisplay.svelte
+++ b/src/components/ResourceDisplay.svelte
@@ -10,7 +10,7 @@
 
 <a
   href={resource.pdfLink}
-  class="border border-primary70 bg-secondary96 dark:bg-secondary20 shadow-customXl dark:shadow-none rounded-xl p-4 w-full md:w-3/4 lg:w-1/2 m-1 hover:bg-secondary93 dark:hover:bg-secondary10 hover:text-white hover:shadow-none duration-200"
+  class="border border-primary70 bg-secondary96 dark:bg-secondary20 shadow-customXl dark:shadow-none rounded-xl p-4 w-full md:w-3/4 lg:w-1/2 m-1 active:bg-secondary93 dark:active:bg-secondary10 active:text-white active:shadow-none [@media(hover:hover)]:hover:bg-secondary93 [@media(hover:hover)]:dark:hover:bg-secondary10 [@media(hover:hover)]:hover:text-white [@media(hover:hover)]:hover:shadow-none duration-200"
   target="_blank"
 >
   <div class="text-primary10 dark:text-primary90 sm:text-lg">

--- a/src/components/SongDisplay.svelte
+++ b/src/components/SongDisplay.svelte
@@ -10,7 +10,7 @@
 
 <a
   href={song.songPdfLink}
-  class="border border-primary70 bg-secondary96 dark:bg-secondary20 shadow-customXl dark:shadow-none rounded-xl p-4 w-full md:w-3/4 lg:w-1/2 m-1 hover:bg-secondary93 dark:hover:bg-secondary10 hover:text-white hover:shadow-none duration-200"
+  class="border border-primary70 bg-secondary96 dark:bg-secondary20 shadow-customXl dark:shadow-none rounded-xl p-4 w-full md:w-3/4 lg:w-1/2 m-1 active:bg-secondary93 dark:active:bg-secondary10 active:text-white active:shadow-none [@media(hover:hover)]:hover:bg-secondary93 [@media(hover:hover)]:dark:hover:bg-secondary10 [@media(hover:hover)]:hover:text-white [@media(hover:hover)]:hover:shadow-none duration-200"
   target="_blank"
 >
   <div class="text-sm text-primary10 dark:text-primary90 sm:text-lg">

--- a/src/routes/bass/+page.svelte
+++ b/src/routes/bass/+page.svelte
@@ -40,7 +40,7 @@
   {/if}
   {#if $songs.length > 0}
     <button
-      class="w-full text-sm text-tertiary50 hover:text-tertiary80 duration-200"
+      class="w-full text-sm text-tertiary50 active:text-tertiary80 duration-200 [@media(hover:hover)]:hover:text-tertiary80"
       onclick={randomizeSongs}
     >
       Randomize order

--- a/src/routes/bass/+page.svelte
+++ b/src/routes/bass/+page.svelte
@@ -40,7 +40,7 @@
   {/if}
   {#if $songs.length > 0}
     <button
-      class="w-full text-sm text-tertiary50 active:text-tertiary80 duration-200 [@media(hover:hover)]:hover:text-tertiary80"
+      class="text-sm text-tertiary50 active:text-tertiary80 duration-200 [@media(hover:hover)]:hover:text-tertiary80"
       onclick={randomizeSongs}
     >
       Randomize order

--- a/src/routes/drums/+page.svelte
+++ b/src/routes/drums/+page.svelte
@@ -34,7 +34,7 @@
     Drums Songs
   </h2>
   <button
-    class="w-full text-sm text-tertiary50 hover:text-tertiary80 duration-200"
+    class="w-full text-sm text-tertiary50 active:text-tertiary80 duration-200 [@media(hover:hover)]:hover:text-tertiary80"
     onclick={randomizeSongs}
   >
     Randomize order

--- a/src/routes/drums/+page.svelte
+++ b/src/routes/drums/+page.svelte
@@ -34,7 +34,7 @@
     Drums Songs
   </h2>
   <button
-    class="w-full text-sm text-tertiary50 active:text-tertiary80 duration-200 [@media(hover:hover)]:hover:text-tertiary80"
+    class="text-sm text-tertiary50 active:text-tertiary80 duration-200 [@media(hover:hover)]:hover:text-tertiary80"
     onclick={randomizeSongs}
   >
     Randomize order

--- a/src/routes/guitar/+page.svelte
+++ b/src/routes/guitar/+page.svelte
@@ -34,7 +34,7 @@
     Guitar Songs
   </h2>
   <button
-    class="w-full text-sm text-tertiary50 active:text-tertiary80 duration-200 [@media(hover:hover)]:hover:text-tertiary80"
+    class="text-sm text-tertiary50 active:text-tertiary80 duration-200 [@media(hover:hover)]:hover:text-tertiary80"
     onclick={randomizeSongs}
   >
     Randomize order

--- a/src/routes/guitar/+page.svelte
+++ b/src/routes/guitar/+page.svelte
@@ -34,7 +34,7 @@
     Guitar Songs
   </h2>
   <button
-    class="w-full text-sm text-tertiary50 hover:text-tertiary80 duration-200"
+    class="w-full text-sm text-tertiary50 active:text-tertiary80 duration-200 [@media(hover:hover)]:hover:text-tertiary80"
     onclick={randomizeSongs}
   >
     Randomize order


### PR DESCRIPTION
- Added active and @media queries to buttons on guitar, drums, and bass pages to fix problem with button press color sticking on mobile
- Then applied the same mediaquery solution to the a elements in ResourceDisplay and SongDisplay
- Removed w-full on all "Randomize order" buttons on guitar, drums, and bass pages so that the color changes only when hovering over the text
- Added active to Tailwind classes in a tags in Footer to fix the sticky color issue there too