### PR TITLE
Fix on press color change on mobile

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -38,8 +38,8 @@
       This archive contains teaching materials I’ve created or adapted for
       students over the years. These resources were either useful for teaching
       music concepts or specifically requested by students. Most songs were
-      arranged or written by me, although some are refined adaptations of
-      others’ arrangements or tabs found online. All PDFs are free to download.
+      transcribed by me, although some are based on others’ charts or tabs found
+      online, which I then modified. All PDFs are free to download.
     </p>
     <br />
     <p>

--- a/src/routes/bass/+page.svelte
+++ b/src/routes/bass/+page.svelte
@@ -40,7 +40,7 @@
   {/if}
   {#if $songs.length > 0}
     <button
-      class="text-sm text-tertiary70 active:text-tertiary80 duration-200 hover:text-tertiary50"
+      class="text-sm text-tertiary50 sm:hover:text-tertiary40 active:text-tertiary40 duration-200 p-2 touch-manipulation"
       onclick={randomizeSongs}
     >
       Randomize order

--- a/src/routes/drums/+page.svelte
+++ b/src/routes/drums/+page.svelte
@@ -34,7 +34,7 @@
     Drums Songs
   </h2>
   <button
-    class="text-sm text-tertiary70 active:text-tertiary80 duration-200 hover:text-tertiary50"
+    class="text-sm text-tertiary50 sm:hover:text-tertiary40 active:text-tertiary40 duration-200 p-2 touch-manipulation"
     onclick={randomizeSongs}
   >
     Randomize order

--- a/src/routes/guitar/+page.svelte
+++ b/src/routes/guitar/+page.svelte
@@ -34,7 +34,7 @@
     Guitar Songs
   </h2>
   <button
-    class="text-sm text-tertiary70 active:text-tertiary80 duration-200 hover:text-tertiary50"
+    class="text-sm text-tertiary50 sm:hover:text-tertiary40 active:text-tertiary40 duration-200 p-2 touch-manipulation"
     onclick={randomizeSongs}
   >
     Randomize order


### PR DESCRIPTION
Modified Tailwind "Randomize order" button on guit, drums, and bass pages to only have hover on larger screens so when pressed on mobile, color doesn't get stuck on pressed color.