### PR TITLE
Add scroll to top buttons

### DIFF
--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -12,14 +12,16 @@
       href="https://github.com/BrettEastman/bretteastmanstudio/"
       target="_blank"
       class="text-primary30 dark:text-primary50 active:text-tertiary80 transition duration-200"
-      ><Icon name="github" className="fill-current" size="36" />
+    >
+      <Icon name="github" className="fill-current" size="36" />
     </a>
 
     <a
       href="https://www.linkedin.com/in/brett-austin-eastman/"
       target="_blank"
       class="text-primary30 dark:text-primary50 active:text-tertiary80 transition duration-200"
-      ><Icon name="linkedin" className="fill-current" size="36" />
+    >
+      <Icon name="linkedin" className="fill-current" size="36" />
     </a>
   </div>
 </footer>

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -183,11 +183,11 @@
         class="flex flex-col bg-secondary93 dark:bg-secondary20 rounded-md px-4 py-2 shadow-lg"
       >
         {#each navItems as item}
-          <li class="my-2">
+          <li class="my-2 w-full">
             <a
               href={item.href}
               onclick={toggleMobileMenu}
-              class="px-4 text-primary30 dark:text-tertiary90 hover:text-tertiary60 duration-200"
+              class="flex px-4 w-full text-primary30 dark:text-tertiary90 hover:text-tertiary60 duration-200"
             >
               {item.name}
             </a>

--- a/src/components/Icon.svelte
+++ b/src/components/Icon.svelte
@@ -35,3 +35,17 @@
     />
   </svg>
 {/if}
+
+{#if name === "arrow-up-s-line"}
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    class={className}
+  >
+    <path
+      d="M11.9999 10.8284L7.0502 15.7782L5.63599 14.364L11.9999 8L18.3639 14.364L16.9497 15.7782L11.9999 10.8284Z"
+    />
+  </svg>
+{/if}

--- a/src/routes/bass/+page.svelte
+++ b/src/routes/bass/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { writable } from "svelte/store";
+  import Icon from "../../components/Icon.svelte";
   import SongDisplay from "../../components/SongDisplay.svelte";
   import type { PageData } from "./$types";
 
@@ -10,6 +11,7 @@
   let { data }: Props = $props();
 
   let searchQuery = $state("");
+  let y = $state(0);
 
   const songs = writable(data.songList);
 
@@ -58,7 +60,20 @@
       </p>
     {/if}
   </ul>
+
+  <div
+    class={`
+  fixed bottom-0 left-0 px-2 py-8 sm:p-12 z-10 transition-opacity duration-200
+  ${y <= 100 ? "opacity-0 pointer-events-none" : "opacity-100"}
+`}
+  >
+    <button onclick={() => window.scrollTo({ top: 0, behavior: "smooth" })}>
+      <Icon name="arrow-up-s-line" size="36" className="fill-current" />
+    </button>
+  </div>
 </div>
+
+<svelte:window bind:scrollY={y} />
 
 <style>
   .song-item {

--- a/src/routes/drums/+page.svelte
+++ b/src/routes/drums/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { writable } from "svelte/store";
+  import Icon from "../../components/Icon.svelte";
   import SongDisplay from "../../components/SongDisplay.svelte";
   import type { PageData } from "./$types";
 
@@ -10,6 +11,7 @@
   let { data }: Props = $props();
 
   let searchQuery = $state("");
+  let y = $state(0);
 
   const songs = writable(data.songList);
 
@@ -58,7 +60,20 @@
       </p>
     {/if}
   </ul>
+
+  <div
+    class={`
+  fixed bottom-0 left-0 px-2 py-8 sm:p-12 z-10 transition-opacity duration-200
+  ${y <= 100 ? "opacity-0 pointer-events-none" : "opacity-100"}
+`}
+  >
+    <button onclick={() => window.scrollTo({ top: 0, behavior: "smooth" })}>
+      <Icon name="arrow-up-s-line" size="36" className="fill-current" />
+    </button>
+  </div>
 </div>
+
+<svelte:window bind:scrollY={y} />
 
 <style>
   .song-item {

--- a/src/routes/guitar/+page.svelte
+++ b/src/routes/guitar/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { writable } from "svelte/store";
+  import Icon from "../../components/Icon.svelte";
   import SongDisplay from "../../components/SongDisplay.svelte";
   import type { PageData } from "./$types";
 
@@ -10,6 +11,7 @@
   let { data }: Props = $props();
 
   let searchQuery = $state("");
+  let y = $state(0);
 
   const songs = writable(data.songList);
 
@@ -59,7 +61,20 @@
       </p>
     {/if}
   </ul>
+
+  <div
+    class={`
+    fixed bottom-0 left-0 px-2 py-8 sm:p-12 z-10 transition-opacity duration-200
+    ${y <= 100 ? "opacity-0 pointer-events-none" : "opacity-100"}
+  `}
+  >
+    <button onclick={() => window.scrollTo({ top: 0, behavior: "smooth" })}>
+      <Icon name="arrow-up-s-line" size="36" className="fill-current" />
+    </button>
+  </div>
 </div>
+
+<svelte:window bind:scrollY={y} />
 
 <style>
   .song-item {

--- a/src/routes/theory/+page.svelte
+++ b/src/routes/theory/+page.svelte
@@ -75,22 +75,4 @@
       }
     }
   }
-
-  @supports not (animation-timeline: view()) {
-    .resource-item {
-      animation: fallback-fade 0.5s ease-out forwards;
-      animation-delay: calc(var(--index) * 100ms);
-    }
-
-    @keyframes fallback-fade {
-      from {
-        opacity: 0;
-        transform: translateY(20px);
-      }
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
-    }
-  }
 </style>

--- a/src/routes/theory/+page.svelte
+++ b/src/routes/theory/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { ResourceItem } from "$lib/types";
+  import Icon from "../../components/Icon.svelte";
   import ResourceDisplay from "../../components/ResourceDisplay.svelte";
   import type { PageData } from "./$types";
 
@@ -10,6 +11,7 @@
   let { data }: Props = $props();
 
   let searchQuery = $state("");
+  let y = $state(0);
 
   let filteredResources = $derived(
     data.resourceList.filter((resource: ResourceItem) => {
@@ -46,7 +48,20 @@
       </p>
     {/if}
   </ul>
+
+  <div
+    class={`
+    fixed bottom-0 left-0 px-2 py-8 sm:p-12 z-10 transition-opacity duration-200
+    ${y <= 100 ? "opacity-0 pointer-events-none" : "opacity-100"}
+  `}
+  >
+    <button onclick={() => window.scrollTo({ top: 0, behavior: "smooth" })}>
+      <Icon name="arrow-up-s-line" size="36" className="fill-current" />
+    </button>
+  </div>
 </div>
+
+<svelte:window bind:scrollY={y} />
 
 <style>
   .resource-item {


### PR DESCRIPTION
- Added scroll to top buttons on guitar page, drums, bass, and theory pages as well, with opacity change on scroll
- Added arrow up icon to Icon component
- Removed unneeded animation-timeline substitute CSS for Safari in Theory page
- Reformat the Footer slightly
- Added flex to anchor tag in mobile nav in Header so user can has a wider area to click for the link