### PR TITLE
feat: A

### DIFF
--- a/src/components/SongDisplay.svelte
+++ b/src/components/SongDisplay.svelte
@@ -6,6 +6,8 @@
   }
 
   let { song }: Props = $props();
+
+  let width = $state(0);
 </script>
 
 <a
@@ -14,12 +16,24 @@
   target="_blank"
   aria-label="Download {song.songTitle} by {song.artistName} ({song.instrumentDescription})"
 >
-  <div class="text-xs text-primary10 dark:text-primary90 sm:text-sm md:text-lg">
-    <p>Title: <b class="px-3 sm:px-[14px]">{song.songTitle}</b></p>
+  <div
+    class="text-sm text-primary10 dark:text-primary90 sm:text-base md:text-lg"
+  >
+    <p>
+      {width > 768 ? "Title: " : ""}<b
+        class={`${width > 768 ? "px-3" : "px-0"}`}>{song.songTitle}</b
+      >
+    </p>
     <div class="flex justify-between">
-      <span>Artist: <b class="px-1">{song.artistName}</b></span>
+      <span
+        >{width > 768 ? "Artist: " : ""}<b
+          class={`${width > 768 ? "px-1" : "px-0"}`}>{song.artistName}</b
+        >
+      </span>
       <span class="text-xs flex items-center">{song.instrumentDescription}</span
       >
     </div>
   </div>
 </a>
+
+<svelte:window bind:innerWidth={width} />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
 
 <div class="flex flex-col items-center px-8 py-4">
   <h1 class="text-2xl text-primary10 dark:text-primary80 font-semibold py-8">
-    Home Page
+    Home
   </h1>
   <div
     class="text-md text-primary10 dark:text-primary80 sm:text-lg md:w-3/4 lg:w-1/2"
@@ -54,23 +54,23 @@
       </a> who loves to give recommendations of artists, albums, and songs to listen
       to. You can ask about any music history topic, or find out more about the background
       of a song, artist, or album, and the AI will do its best to provide an informative
-      response. And it may even give you a recommendation or two! Please log in to
-      use the chat feature.
+      response. Please log in to use the chat feature.
     </p>
     <br />
     <p>
-      And for the drummers out there, you may also be interested in purchasing
-      my drum book,
+      For the drummers out there, you may also be interested in purchasing my
+      drum book,
       <a
         href="https://www.amazon.com/gp/product/B09QGB3TM3?ref_=dbs_m_mng_rwt_calw_tpbk_0&storeType=ebooks&qid=1731269493&sr=8-1"
         target="_blank"
         aria-label="Patterns and Beats on Amazon"
         class="text-links">Patterns and Beats</a
       >, which is intended for beginner to intermediate level students. It is a
-      very useful reference and guide, which contains collections of linear
-      patterns and a curated selection of drum beats, arranged in logical order
-      of difficulty. The layout was designed for readability, clarity and
-      comfort. It is available on paperback and e-book.
+      very useful reference and guide which I wrote specifically to use with my
+      students. It contains collections of linear patterns and a curated
+      selection of drum beats, arranged in logical order of difficulty. The
+      minimalist layout was designed for readability, clarity and comfort. It is
+      available on paperback and e-book.
     </p>
     <a
       href="https://www.amazon.com/gp/product/B09QGB3TM3?ref_=dbs_m_mng_rwt_calw_tpbk_0&storeType=ebooks&qid=1731269493&sr=8-1"

--- a/src/routes/bass/+page.svelte
+++ b/src/routes/bass/+page.svelte
@@ -36,7 +36,7 @@
     Bass Songs
   </h2>
   <button
-    class="text-sm text-tertiary50 sm:hover:text-tertiary40 active:text-tertiary40 duration-200 p-4"
+    class="text-sm text-tertiary50 dark:text-tertiary60 sm:hover:text-tertiary40 active:text-tertiary40 duration-200 p-4"
     onclick={randomizeSongs}
     aria-label="Randomize song order"
   >

--- a/src/routes/bass/+page.svelte
+++ b/src/routes/bass/+page.svelte
@@ -72,7 +72,7 @@
     <button
       onclick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
       aria-label="Scroll to top of page"
-      class="px-3 py-8 sm:p-12"
+      class="px-3 py-6 sm:p-6"
     >
       <Icon
         name="arrow-up-s-line"

--- a/src/routes/drums/+page.svelte
+++ b/src/routes/drums/+page.svelte
@@ -36,7 +36,7 @@
     Drums Songs
   </h2>
   <button
-    class="text-sm text-tertiary50 sm:hover:text-tertiary40 active:text-tertiary40 duration-200 p-4"
+    class="text-sm text-tertiary50 dark:text-tertiary60 sm:hover:text-tertiary40 active:text-tertiary40 duration-200 p-4"
     onclick={randomizeSongs}
     aria-label="Randomize song order"
   >

--- a/src/routes/drums/+page.svelte
+++ b/src/routes/drums/+page.svelte
@@ -72,7 +72,7 @@
     <button
       onclick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
       aria-label="Scroll to top of page"
-      class="px-3 py-8 sm:p-12"
+      class="px-3 py-6 sm:p-6"
     >
       <Icon
         name="arrow-up-s-line"

--- a/src/routes/guitar/+page.svelte
+++ b/src/routes/guitar/+page.svelte
@@ -73,7 +73,7 @@
     <button
       onclick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
       aria-label="Scroll to top of page"
-      class="px-3 py-8 sm:p-12"
+      class="px-3 py-6 sm:p-6"
     >
       <Icon
         name="arrow-up-s-line"

--- a/src/routes/guitar/+page.svelte
+++ b/src/routes/guitar/+page.svelte
@@ -36,7 +36,7 @@
     Guitar Songs
   </h2>
   <button
-    class="text-sm text-tertiary50 sm:hover:text-tertiary40 active:text-tertiary40 duration-200 p-4"
+    class="text-sm text-tertiary50 dark:text-tertiary60 sm:hover:text-tertiary40 active:text-tertiary40 duration-200 p-4"
     onclick={randomizeSongs}
     aria-label="Randomize song order"
   >

--- a/src/routes/theory/+page.svelte
+++ b/src/routes/theory/+page.svelte
@@ -59,7 +59,7 @@
     <button
       onclick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
       aria-label="Scroll to top of page"
-      class="px-3 py-8 sm:p-12"
+      class="px-3 py-6 sm:p-6"
     >
       <Icon
         name="arrow-up-s-line"


### PR DESCRIPTION
- Added svelte:window in SongDisplay to keep track of innerwidth and change things responsively that way - Removed "Artist" and "Title" when screen is below 768
- Made SongDisplay text bigger
- Modified text on Home page
- Lessened padding on arrow-up on guitar page
- Changed arrow-up padding on bass, drums, and theory pages to match guitar page
- Modified CSS dark mode color on Randomize order button for guit, bass and drums