### PR TITLE
Add PocketBase file upload support with Google Drive fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ vite.config.ts.timestamp-*
 seedDB.js
 seedResources.js
 content
+upload-song-pdfs.js
+upload-README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev          # Start development server
+npm run build        # Build for production
+npm run preview      # Preview production build
+npm run check        # Run svelte-check for type checking
+npm run check:watch  # Run svelte-check in watch mode
+npm run lint         # Run ESLint
+```
+
+## Architecture
+
+This is a SvelteKit 2 application using Svelte 5 syntax, deployed to Cloudflare Pages.
+
+### Key Technologies
+- **Frontend**: Svelte 5 with runes (`$state`, `$derived`, `$effect`, `$props`)
+- **Backend**: PocketBase (self-hosted on Linode at api.bretteastmanstudio.com)
+- **AI**: Google Gemini 2.5 Flash for the music history chatbot
+- **Styling**: TailwindCSS with custom color tokens (primary, secondary, tertiary with numeric suffixes)
+- **Deployment**: Cloudflare adapter
+
+### Data Flow
+- `src/hooks.server.ts` - Server hook that initializes PocketBase for each request, handles auth state via cookies, and protects `/chat` route
+- `src/lib/pocketbase.ts` - Factory function that creates PocketBase instances (browser-side caches instance on window, server-side creates fresh per request)
+- `src/lib/server/gemini.ts` - Server-only Gemini AI client with music historian system prompt
+
+### Route Patterns
+- Instrument pages (`/drums`, `/bass`, `/guitar`, `/theory`) - Load song data via `+page.ts` using PocketBase client-side, display with search and randomize features
+- `/chat` - Protected route requiring authentication, communicates with `/api/chat` endpoint
+- `/api/chat` - Server endpoint that enforces daily question limit (10/day per user), maintains conversation history with Gemini
+
+### Type Definitions
+- `src/lib/types.ts` - Shared types for songs, resources, chat messages, and Gemini API payloads
+- `src/app.d.ts` - SvelteKit app types extending `App.Locals` with `pb` and `user`
+
+### Environment Variables
+- Prefix `PUBLIC_` for client-accessible vars
+- Prefix `PRIVATE_` for server-only vars (e.g., `PRIVATE_GEMINI_API_KEY`)
+
+### Components
+- Components in `src/components/` use Svelte 5 `interface Props` pattern with `$props()` rune
+- Icons via `Icon.svelte` component using Remix icons

--- a/src/components/ResourceDisplay.svelte
+++ b/src/components/ResourceDisplay.svelte
@@ -1,15 +1,24 @@
 <script lang="ts">
   import type { ResourceItem } from "$lib/types";
 
+  const POCKETBASE_URL = "https://api.bretteastmanstudio.com";
+
   interface Props {
     resource: ResourceItem;
   }
 
   let { resource }: Props = $props();
+
+  // Prefer PocketBase file, fall back to Google Drive link
+  let pdfUrl = $derived(
+    resource.pdfFile
+      ? `${POCKETBASE_URL}/api/files/resources/${resource.id}/${resource.pdfFile}`
+      : resource.pdfLink
+  );
 </script>
 
 <a
-  href={resource.pdfLink}
+  href={pdfUrl}
   class="border border-primary70 bg-secondary96 dark:bg-secondary20 shadow-customXl dark:shadow-none rounded-xl p-4 w-full md:w-3/4 lg:w-1/2 m-1 active:bg-secondary93 dark:active:bg-secondary10 active:text-white active:shadow-none hover:bg-secondary93 dark:hover:bg-secondary10 hover:text-white hover:shadow-none duration-200"
   target="_blank"
   aria-label="Download {resource.description} ({resource.instrument})"

--- a/src/components/SongDisplay.svelte
+++ b/src/components/SongDisplay.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import type { SongItem } from "$lib/types";
 
+  const POCKETBASE_URL = "https://api.bretteastmanstudio.com";
+
   interface Props {
     song: SongItem;
   }
@@ -8,10 +10,17 @@
   let { song }: Props = $props();
 
   let width = $state(0);
+
+  // Prefer PocketBase file, fall back to Google Drive link
+  let pdfUrl = $derived(
+    song.songPdfFile
+      ? `${POCKETBASE_URL}/api/files/songs/${song.id}/${song.songPdfFile}`
+      : song.songPdfLink
+  );
 </script>
 
 <a
-  href={song.songPdfLink}
+  href={pdfUrl}
   class="border border-primary70 bg-secondary96 dark:bg-secondary20 shadow-customXl dark:shadow-none rounded-xl p-4 w-full md:w-3/4 lg:w-1/2 m-1 active:bg-secondary93 dark:active:bg-secondary10 active:text-white active:shadow-none hover:bg-secondary93 dark:hover:bg-secondary10 hover:text-white hover:shadow-none duration-200"
   target="_blank"
   aria-label="Download {song.songTitle} by {song.artistName} ({song.instrumentDescription})"

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -30,9 +30,11 @@ export type InstrDescription =
   | "Guitar-chords-tab";
 
 export interface ResourceItem {
+  id: string;
   description: string;
   instrument: ResourceInstrument;
   pdfLink: string;
+  pdfFile?: string;
 }
 
 export interface SongItem {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,10 +38,12 @@ export interface ResourceItem {
 }
 
 export interface SongItem {
+  id: string;
   songTitle: string;
   instrumentDescription: InstrDescription;
   artistName: string;
   songPdfLink: string;
+  songPdfFile?: string;
 }
 
 export type SongList = SongItem[];

--- a/src/routes/bass/+page.ts
+++ b/src/routes/bass/+page.ts
@@ -10,10 +10,12 @@ export const load: PageLoad = async () => {
     });
 
     const songList: SongList = records.map((record) => ({
+      id: record.id,
       songTitle: record.songTitle,
       instrumentDescription: record.instrumentDescription,
       artistName: record.artistName,
       songPdfLink: record.songPdfLink,
+      songPdfFile: record.songPdfFile,
     }));
 
     return {

--- a/src/routes/drums/+page.ts
+++ b/src/routes/drums/+page.ts
@@ -10,10 +10,12 @@ export const load: PageLoad = async () => {
     });
 
     const songList: SongList = records.map((record) => ({
+      id: record.id,
       songTitle: record.songTitle,
       instrumentDescription: record.instrumentDescription,
       artistName: record.artistName,
       songPdfLink: record.songPdfLink,
+      songPdfFile: record.songPdfFile,
     }));
 
     return {

--- a/src/routes/guitar/+page.ts
+++ b/src/routes/guitar/+page.ts
@@ -10,10 +10,12 @@ export const load: PageLoad = async () => {
     });
 
     const songList: SongList = records.map((record) => ({
+      id: record.id,
       songTitle: record.songTitle,
       instrumentDescription: record.instrumentDescription,
       artistName: record.artistName,
       songPdfLink: record.songPdfLink,
+      songPdfFile: record.songPdfFile,
     }));
 
     return {

--- a/src/routes/theory/+page.ts
+++ b/src/routes/theory/+page.ts
@@ -10,9 +10,11 @@ export const load: PageLoad = async () => {
     });
 
     const resourceList: ResourceList = records.map((record) => ({
+      id: record.id,
       description: record.description,
       instrument: record.instrument,
       pdfLink: record.pdfLink,
+      pdfFile: record.pdfFile,
     }));
 
     return {


### PR DESCRIPTION
## Summary
- Add support for hosting PDF files directly on PocketBase for both songs and resources
- Implement graceful fallback to Google Drive links for backwards compatibility
- Add CLAUDE.md project documentation for AI assistant guidance
- Update .gitignore to exclude upload scripts from version control

## Changes
**Backend/Data:**
- Update `SongItem` and `ResourceItem` types to include `id` and file fields (`songPdfFile`, `pdfFile`)
- Modify page loaders (bass, drums, guitar, theory) to fetch new PocketBase file fields

**Frontend:**
- Update `SongDisplay.svelte` to prefer PocketBase-hosted PDFs, fallback to Google Drive
- Update `ResourceDisplay.svelte` with same PocketBase-first logic
- Both components now use derived URLs based on file availability

**Documentation:**
- Add comprehensive CLAUDE.md with architecture, commands, and development patterns

## Test plan
- [ ] Verify songs with PocketBase PDFs load from PocketBase URLs
- [ ] Verify songs without PocketBase PDFs still use Google Drive links
- [ ] Test on all instrument pages: /drums, /bass, /guitar
- [ ] Test /theory page for resources
- [ ] Confirm PDF links open correctly in new tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)