### PR TITLE
Chat UI: markdown rendering, layout, and theme fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@google/genai": "^1.40.0",
+        "marked": "^17.0.3",
         "pocketbase": "^0.21.5"
       },
       "devDependencies": {
@@ -16,6 +17,7 @@
         "@sveltejs/adapter-cloudflare": "^7.2.6",
         "@sveltejs/kit": "^2.50.2",
         "@sveltejs/vite-plugin-svelte": "^6.2.4",
+        "@tailwindcss/typography": "^0.5.19",
         "@types/eslint": "^9.6.1",
         "autoprefixer": "^10.4.24",
         "eslint": "^9.16.0",
@@ -30,7 +32,7 @@
         "vite": "^6.3.0"
       },
       "engines": {
-        "node": ">=18.18.0"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2125,6 +2127,33 @@
         "vite": "^6.3.0 || ^7.0.0"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -4026,6 +4055,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.3.tgz",
+      "integrity": "sha512-jt1v2ObpyOKR8p4XaUJVk3YWRJ5n+i4+rjQopxvV32rSndTJXvIzuUdWWIy/1pFQMkQmvTXawzDNqOH/CUmx6A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/merge2": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@sveltejs/adapter-cloudflare": "^7.2.6",
     "@sveltejs/kit": "^2.50.2",
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
+    "@tailwindcss/typography": "^0.5.19",
     "@types/eslint": "^9.6.1",
     "autoprefixer": "^10.4.24",
     "eslint": "^9.16.0",
@@ -34,6 +35,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.40.0",
+    "marked": "^17.0.3",
     "pocketbase": "^0.21.5"
   }
 }

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -106,13 +106,17 @@
 >
   <div class="flex flex-row justify-between items-center sm:hidden">
     <div>
-      <a
-        href="/"
-        class="logo"
-        aria-label="Home - Brett Eastman Studio"
-      >
-        <img src="/images/bes-logo.png" alt="Brett Eastman Studio" class="logo-img block dark:hidden" />
-        <img src="/images/bes-logo-dark.png" alt="Brett Eastman Studio" class="logo-img hidden dark:block" />
+      <a href="/" class="logo" aria-label="Home - Brett Eastman Studio">
+        <img
+          src="/images/bes-logo.png"
+          alt="Brett Eastman Studio"
+          class="logo-img block dark:hidden"
+        />
+        <img
+          src="/images/bes-logo-dark.png"
+          alt="Brett Eastman Studio"
+          class="logo-img hidden dark:block"
+        />
       </a>
     </div>
 
@@ -135,8 +139,16 @@
           class="logo hidden sm:block pl-4"
           aria-label="Home - Brett Eastman Studio"
         >
-          <img src="/images/bes-logo.png" alt="Brett Eastman Studio" class="logo-img block dark:hidden" />
-          <img src="/images/bes-logo-dark.png" alt="Brett Eastman Studio" class="logo-img hidden dark:block" />
+          <img
+            src="/images/bes-logo.png"
+            alt="Brett Eastman Studio"
+            class="logo-img block dark:hidden"
+          />
+          <img
+            src="/images/bes-logo-dark.png"
+            alt="Brett Eastman Studio"
+            class="logo-img hidden dark:block"
+          />
         </a>
         <!-- Desktop nav -->
         <ul class="hidden sm:flex justify-end items-center" role="menubar">
@@ -155,7 +167,7 @@
             <li class="mx-4" role="none">
               <button
                 onclick={handleLogout}
-                class="bg-secondary80 text-primary20 px-4 py-2 rounded-lg hover:bg-secondary60 dark:bg-secondary30 dark:text-tertiary90 duration-200"
+                class="font-manrope tracking-widest bg-secondary80 text-primary20 px-4 py-2 rounded-lg hover:bg-secondary60 dark:bg-secondary30 dark:text-tertiary90 duration-200"
                 role="menuitem"
                 aria-label="Logout {pb?.authStore.model?.name}"
               >
@@ -166,7 +178,7 @@
             <li class="mx-4" role="none">
               <a
                 href="/login"
-                class="bg-secondary80 text-primary20 px-4 py-2 rounded-lg hover:bg-secondary60 dark:bg-secondary30 dark:text-tertiary90 duration-200"
+                class="font-manrope tracking-widestbg-secondary80 text-primary20 px-4 py-2 rounded-lg hover:bg-secondary60 dark:bg-secondary30 dark:text-tertiary90 duration-200"
                 role="menuitem"
               >
                 Login

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -1,0 +1,10 @@
+import { marked } from "marked";
+
+/**
+ * Converts a markdown string to HTML for use with Svelte's {@html}.
+ * Used for rendering AI chat responses (and optionally user messages).
+ */
+export function markdownToHtml(markdown: string): string {
+  if (!markdown?.trim()) return "";
+  return marked.parse(markdown.trim(), { async: false }) as string;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -11,10 +11,10 @@
   let { children }: Props = $props();
 </script>
 
-<div>
+<div class="flex h-svh flex-col overflow-hidden">
   <Header />
-  <div class="h-fit min-h-svh bg-secondary97 dark:bg-secondary10">
+  <main class="min-h-0 flex-1 flex flex-col overflow-auto bg-secondary97 dark:bg-secondary10">
     {@render children?.()}
-  </div>
+  </main>
   <Footer />
 </div>

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -2,6 +2,7 @@
   import { createPocketBaseInstance } from "$lib/pocketbase";
   import type { ChatMessage } from "$lib/types";
   import { formatDateTime } from "$lib/utils/formatDateTime";
+  import { markdownToHtml } from "$lib/utils/markdown";
   import { onMount } from "svelte";
 
   let messages: ChatMessage[] = $state([]);
@@ -101,8 +102,8 @@
   });
 </script>
 
-<div class="p-6 h-svh">
-  <div class="max-w-3xl mx-auto">
+<div class="flex flex-1 flex-col min-h-0 p-6">
+  <div class="mx-auto flex w-full max-w-3xl flex-1 flex-col min-h-0">
     <h2
       class="text-2xl text-primary30 font-semibold text-center my-8 pb-4 dark:text-secondary90"
     >
@@ -125,59 +126,76 @@
       </div>
     {:else}
       <div
-        bind:this={messageContainer}
-        class="bg-secondary90 shadow-lg p-4 mb-4 h-[600px] overflow-y-auto dark:bg-secondary30"
+        class="flex flex-1 flex-col min-h-0 rounded-lg overflow-hidden"
       >
-        {#each messages as message (message.id)}
-          <div class="mb-4">
-            <div class="bg-secondary80 p-3 rounded-lg mb-2 dark:bg-secondary90">
-              <div class="flex justify-between">
-                <p class="font-semibold">You:</p>
-                <p class="text-xs text-primary30">
-                  {formatDateTime(message.created)}
-                </p>
+        <!-- Scrollable messages (history loads here; scroll up to see previous chats) -->
+        <div
+          bind:this={messageContainer}
+          class="flex-1 min-h-0 overflow-y-auto bg-secondary90 dark:bg-secondary30 shadow-lg p-4"
+        >
+          {#each messages as message (message.id)}
+            <div class="mb-4">
+              <div
+                class="bg-secondary80 p-3 rounded-lg mb-2 dark:bg-secondary20 text-primary20 dark:text-secondary90"
+              >
+                <div class="flex justify-between">
+                  <p class="font-semibold">You:</p>
+                  <p class="text-xs opacity-80">
+                    {formatDateTime(message.created)}
+                  </p>
+                </div>
+                <p>{message.message}</p>
               </div>
-              <p>{message.message}</p>
-            </div>
-            <div class="bg-tertiary90 p-3 rounded-lg">
-              <div class="flex justify-between">
-                <p class="font-semibold">Music Historian:</p>
-                <p class="text-xs text-primary30">
-                  {formatDateTime(message.created)}
-                </p>
+              <div
+                class="bg-tertiary90 dark:bg-secondary20 p-3 rounded-lg text-primary20 dark:text-secondary90"
+              >
+                <div class="flex justify-between">
+                  <p class="font-semibold">Music Historian:</p>
+                  <p class="text-xs opacity-80">
+                    {formatDateTime(message.created)}
+                  </p>
+                </div>
+                <div
+                  class="prose prose-sm max-w-none dark:prose-invert"
+                >
+                  {@html markdownToHtml(message.response)}
+                </div>
               </div>
-              <p>{message.response}</p>
             </div>
-          </div>
-        {/each}
+          {/each}
+        </div>
 
         {#if loading}
-          <div class="flex justify-center">
+          <div class="flex justify-center py-2 bg-secondary96 dark:bg-secondary20 border-t border-secondary80 dark:border-secondary30">
             <div
               class="animate-spin rounded-full h-8 w-8 border-b-2 border-secondary50"
             ></div>
           </div>
         {:else if error}
-          <div class="text-center text-red-500">{error}</div>
+          <div class="text-center text-red-500 py-2 bg-secondary96 dark:bg-secondary20 border-t border-secondary80 dark:border-secondary30">{error}</div>
         {/if}
-        <form onsubmit={sendMessage} class="flex gap-2">
-          <input
-            type="text"
-            bind:value={newMessage}
-            aria-label="Type your message"
-            placeholder="Ask about any music history topic..."
-            class="flex-1 px-4 rounded-lg border-primary70 shadow-sm focus:border-secondary50 focus:ring-secondary70"
-            disabled={loading}
-          />
-          <button
-            type="submit"
-            aria-label="Send message"
-            class="bg-secondary80 text-primary20 px-4 py-2 rounded-lg hover:bg-secondary60 dark:bg-secondary30 dark:text-tertiary90 duration-200"
-            disabled={loading || !newMessage.trim()}
-          >
-            Send
-          </button>
-        </form>
+
+        <!-- Fixed input bar (always visible, ChatGPT-style) -->
+        <div class="shrink-0 border-t border-secondary80 dark:border-secondary30 bg-secondary96 dark:bg-secondary20 p-4">
+          <form onsubmit={sendMessage} class="flex gap-2 max-w-3xl mx-auto">
+            <input
+              type="text"
+              bind:value={newMessage}
+              aria-label="Type your message"
+              placeholder="Ask about any music history topic..."
+              class="flex-1 px-4 py-2.5 rounded-lg border border-primary70 shadow-sm focus:border-secondary50 focus:ring-secondary70 bg-primary100 dark:bg-secondary10 text-primary10 dark:text-secondary97 placeholder:primary50 dark:placeholder-secondary60"
+              disabled={loading}
+            />
+            <button
+              type="submit"
+              aria-label="Send message"
+              class="bg-secondary80 text-primary20 px-4 py-2.5 rounded-lg hover:bg-secondary60 dark:bg-secondary30 dark:text-tertiary90 duration-200 shrink-0 font-medium"
+              disabled={loading || !newMessage.trim()}
+            >
+              Send
+            </button>
+          </form>
+        </div>
       </div>
     {/if}
   </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+import typography from "@tailwindcss/typography";
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./src/**/*.{html,js,svelte,ts}"],
@@ -45,5 +47,5 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [typography],
 };


### PR DESCRIPTION
### Summary
Improves the Music History AI Chat page with proper markdown rendering, a layout that no longer overlaps the footer, theme-aware colors for light/dark mode, and a fixed input bar with a scrollable message history.

### Changes

**Markdown rendering**
- Integrate **marked** to convert AI responses from markdown to HTML.
- Render output with Svelte’s `{@html ...}` inside a wrapper styled with **@tailwindcss/typography** (`prose prose-sm dark:prose-invert`).
- Add `src/lib/utils/markdown.ts` (`markdownToHtml()`) for reuse and clarity.
- Bold, lists, and other markdown in chat now render correctly instead of showing raw asterisks.

**Layout and scroll**
- Use a flex layout in the root layout (`h-svh overflow-hidden`, main with `flex-1 min-h-0 overflow-auto`) so the app height is constrained to the viewport and the chat no longer bleeds into the footer.
- Make the chat messages area the only scrollable region (`flex-1 min-h-0 overflow-y-auto`) so users can scroll up to see previous messages while the latest appears when they return.
- Keep the input form in a fixed bar at the bottom: separate visual block with its own background and border, always visible below the scrollable messages.

**Colors (light/dark)**
- Adjust chat bubble and input colors so they work in both themes: darker bubbles and light text in dark mode (e.g. `dark:bg-secondary20`, `dark:text-secondary90`), with prose inverted for AI responses.
- Style the input field for both themes (`bg-primary100 dark:bg-secondary10`, `text-primary10 dark:text-secondary97`)