### PR TITLE
Show footer only when scrolled to bottom/Center Nav mobile

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -203,7 +203,7 @@
             <a
               href={item.href}
               onclick={toggleMobileMenu}
-              class="flex px-4 w-full text-primary30 dark:text-tertiary90 hover:text-tertiary60 duration-200"
+              class="flex justify-center w-full text-primary30 dark:text-tertiary90 hover:text-tertiary60 duration-200"
               role="menuitem"
             >
               {item.name}
@@ -211,7 +211,7 @@
           </li>
         {/each}
         {#if isAuthenticated}
-          <li class="my-2" role="none">
+          <li class="mx-auto" role="none">
             <button
               onclick={handleLogout}
               class="bg-secondary80 text-primary20 px-4 py-2 rounded-lg hover:bg-secondary60 dark:bg-secondary30 dark:text-tertiary90 duration-200"

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -222,7 +222,7 @@
             </button>
           </li>
         {:else}
-          <li class="my-2" role="none">
+          <li class="mx-auto" role="none">
             <button
               onclick={handleLogin}
               class="bg-secondary80 text-primary20 px-4 py-2 rounded-lg hover:bg-secondary60 dark:bg-secondary30 dark:text-tertiary90 duration-200"

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,12 +9,50 @@
   }
 
   let { children }: Props = $props();
+  let mainEl: HTMLElement | undefined = $state();
+  let atBottom = $state(false);
+
+  const THRESHOLD = 24;
+
+  function checkScroll() {
+    if (!mainEl) return;
+    const { scrollTop, clientHeight, scrollHeight } = mainEl;
+    atBottom = scrollTop + clientHeight >= scrollHeight - THRESHOLD;
+  }
+
+  $effect(() => {
+    const el = mainEl;
+    if (!el) return;
+    el.addEventListener("scroll", checkScroll);
+    checkScroll();
+    return () => el.removeEventListener("scroll", checkScroll);
+  });
 </script>
 
 <div class="flex h-svh flex-col overflow-hidden">
   <Header />
-  <main class="min-h-0 flex-1 flex flex-col overflow-auto bg-secondary97 dark:bg-secondary10">
+  <main
+    bind:this={mainEl}
+    class="min-h-0 flex-1 flex flex-col overflow-auto bg-secondary97 dark:bg-secondary10"
+  >
     {@render children?.()}
   </main>
-  <Footer />
+  <div
+    class="footer-container"
+    class:footer-visible={atBottom}
+  >
+    <Footer />
+  </div>
 </div>
+
+<style>
+  .footer-container {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.35s ease;
+  }
+
+  .footer-container.footer-visible {
+    max-height: 120px;
+  }
+</style>


### PR DESCRIPTION
### Summary
Footer is hidden by default and only appears once the user has scrolled to the bottom of the main content, with a short transition.

### Changes
- **Layout** (`src/routes/+layout.svelte`): Bind to the scrollable `<main>` element and track scroll position. When the user is within 24px of the bottom, set `atBottom` to true.
- **Footer visibility**: Footer container uses `max-height: 0` by default and `max-height: 120px` when `atBottom` is true, with `overflow: hidden` and a 0.35s ease transition so it slides in/out.
- **Cleanup**: Scroll listener is added in a `$effect` and removed in its cleanup.
- Center the Nav options in mobile

### Notes
- If the footer grows in height, increase the `max-height` value in the `.footer-visible` rule.
- The 24px threshold is in the `THRESHOLD` constant.